### PR TITLE
Fix loading plugin in test file

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,7 @@ import chai, {expect} from 'chai'
 import convertTo from './chai-convert-to'
 
 chai.use(convertTo(
-	{ plugins: ['../', 'syntax-object-rest-spread'] },
+	{ plugins: [require.resolve('../'), 'syntax-object-rest-spread'] },
 	{ plugins: ['syntax-jsx', 'syntax-object-rest-spread'] }))
 
 describe('createElement-to-JSX', () => {


### PR DESCRIPTION
I had an issue when running the test files locally.
I'd get a reference error `Unknown plugin "../" specified`.

It might be a node version issue. I'm running 6.4.

This uses `require.resolve` to fix it.
