### PR TITLE
Rename isSpreadProperty to isSpreadElement

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -116,7 +116,7 @@ export default function({types: t}) {
 	const isPlainObjectExpression = node =>
 		t.isObjectExpression(node) &&
 		node.properties.every(m =>
-			t.isSpreadProperty(m) ||
+			t.isSpreadElement(m) ||
 			(t.isObjectProperty(m, {computed: false}) &&
 				getJSXIdentifier(m.key) !== null &&
 				getJSXAttributeValue(m.value) !== null))


### PR DESCRIPTION
This has been renamed, and babel 7 now throws error if you use old one.